### PR TITLE
payments admin permissions to payments module

### DIFF
--- a/payments.yml
+++ b/payments.yml
@@ -7,6 +7,7 @@ resourcePolicy:
       effect: EFFECT_ALLOW
       roles:
         - ORG_ADMIN
+        - PAYMENTS_ADMIN
     - actions: ["view"]
       effect: EFFECT_ALLOW
       roles:


### PR DESCRIPTION
Full access to payments module for users with `Payments_Admin` role